### PR TITLE
Release/2.3.1

### DIFF
--- a/build-system/dependencies.gradle
+++ b/build-system/dependencies.gradle
@@ -34,8 +34,8 @@ rootProject.ext {
             minSdk     : 21,
             compileSdk : 28,
             targetSdk  : 28,
-            versionCode: 18,
-            versionName: "2.3.0"
+            versionCode: 19,
+            versionName: "2.3.1"
     ]
 
     appDependencies = [

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/viewmodel/EmaBaseViewModel.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/viewmodel/EmaBaseViewModel.kt
@@ -80,7 +80,7 @@ abstract class EmaBaseViewModel<S : EmaBaseState, NS : EmaNavigationState> : Vie
      * @param inputState
      * @return true if it's the first time is started
      */
-    internal open fun onStart(inputState: S? = null): Boolean {
+    open fun onStart(inputState: S? = null): Boolean {
         val firstTime = if (state == null) {
             val initialStatus = inputState ?: createInitialState()
             state = initialStatus


### PR DESCRIPTION
Allow override in vm.onStart
Removed inline to allow override over super method.
Cause: Must force a state in testing