### PR TITLE
Allow override in vm.onStart

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/viewmodel/EmaBaseViewModel.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/viewmodel/EmaBaseViewModel.kt
@@ -80,7 +80,7 @@ abstract class EmaBaseViewModel<S : EmaBaseState, NS : EmaNavigationState> : Vie
      * @param inputState
      * @return true if it's the first time is started
      */
-    internal open fun onStart(inputState: S? = null): Boolean {
+    open fun onStart(inputState: S? = null): Boolean {
         val firstTime = if (state == null) {
             val initialStatus = inputState ?: createInitialState()
             state = initialStatus


### PR DESCRIPTION
Removed inline to allow override over super method.
Cause: Must force a state in testing