### PR TITLE
Dialog changed to public on base dialog provider

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseDialogProvider.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseDialogProvider.kt
@@ -14,7 +14,7 @@ import es.babel.easymvvm.core.dialog.EmaDialogProvider
  */
 abstract class EmaBaseDialogProvider constructor(private val fragmentManager: FragmentManager) : EmaDialogProvider {
 
-    private var dialog: EmaBaseDialog<EmaDialogData>? = null
+    var dialog: EmaBaseDialog<EmaDialogData>? = null
 
     abstract fun generateDialog(): EmaBaseDialog<*>
 


### PR DESCRIPTION
Why:
    - Cause handling the dialog data it's needed.
How:
    - Removing the private annotation.