### PR TITLE
Tag support added to dialogs

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseBottomDialogProvider.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseBottomDialogProvider.kt
@@ -19,17 +19,21 @@ abstract class EmaBaseBottomDialogProvider constructor(private val fragmentManag
 
     abstract fun generateDialog(): EmaBaseBottomSheetDialog<*>
 
-    @Suppress("UNCHECKED_CAST")
-    override fun show(dialogData: EmaDialogData?) {
+    private var tag = javaClass.canonicalName?.hashCode().toString()
 
-        if (dialog == null)
+    @Suppress("UNCHECKED_CAST")
+    override fun show(dialogData: EmaDialogData?, tag: String?) {
+
+        if (dialog == null) {
             dialog = generateDialog() as EmaBaseBottomSheetDialog<EmaBottomDialogData>
+            tag?.let { this.tag = it }
+        }
 
         dialog?.let { dialog ->
             dialog.dialogListener = dialogListener
             dialog.data = dialogData as EmaBottomDialogData?
             if (!dialog.isVisible)
-                dialog.show(fragmentManager, getTag())
+                dialog.show(fragmentManager, this.tag)
 
         }
     }
@@ -41,7 +45,7 @@ abstract class EmaBaseBottomDialogProvider constructor(private val fragmentManag
                 it.dismissAllowingStateLoss()
             }
         } ?: also { _ ->
-            val oldDialog = fragmentManager.findFragmentByTag(getTag())
+            val oldDialog = fragmentManager.findFragmentByTag(tag)
             oldDialog?.also {
                 fragmentManager.beginTransaction().remove(it).commit()
             }
@@ -55,8 +59,4 @@ abstract class EmaBaseBottomDialogProvider constructor(private val fragmentManag
             field = value
             dialog?.dialogListener = value
         }
-
-    private fun getTag():String{
-        return javaClass.canonicalName?.hashCode().toString()
-    }
 }

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseDialogProvider.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/dialog/EmaBaseDialogProvider.kt
@@ -18,17 +18,21 @@ abstract class EmaBaseDialogProvider constructor(private val fragmentManager: Fr
 
     abstract fun generateDialog(): EmaBaseDialog<*>
 
-    @Suppress("UNCHECKED_CAST")
-    override fun show(dialogData: EmaDialogData?) {
+    private var tag = javaClass.canonicalName?.hashCode().toString()
 
-        if (dialog == null)
+    @Suppress("UNCHECKED_CAST")
+    override fun show(dialogData: EmaDialogData?, tag: String?) {
+
+        if (dialog == null) {
             dialog = generateDialog() as EmaBaseDialog<EmaDialogData>
+            tag?.let { this.tag = it }
+        }
 
         dialog?.let { dialog ->
             dialog.dialogListener = dialogListener
             dialog.data = dialogData
             if (!dialog.isVisible)
-                dialog.show(fragmentManager, getTag())
+                dialog.show(fragmentManager, this.tag)
 
         }
     }
@@ -40,7 +44,7 @@ abstract class EmaBaseDialogProvider constructor(private val fragmentManager: Fr
                 it.dismissAllowingStateLoss()
             }
         } ?: also { _ ->
-            val oldDialog = fragmentManager.findFragmentByTag(getTag())
+            val oldDialog = fragmentManager.findFragmentByTag(tag)
             oldDialog?.also {
                 fragmentManager.beginTransaction().remove(it).commit()
             }
@@ -54,8 +58,4 @@ abstract class EmaBaseDialogProvider constructor(private val fragmentManager: Fr
             field = value
             dialog?.dialogListener = value
         }
-
-    private fun getTag():String{
-        return javaClass.canonicalName?.hashCode().toString()
-    }
 }

--- a/easymvvm-core/src/main/java/es/babel/easymvvm/core/dialog/EmaDialogProvider.kt
+++ b/easymvvm-core/src/main/java/es/babel/easymvvm/core/dialog/EmaDialogProvider.kt
@@ -8,7 +8,7 @@ package es.babel.easymvvm.core.dialog
  */
 interface EmaDialogProvider {
 
-    fun show(dialogData: EmaDialogData?=null)
+    fun show(dialogData: EmaDialogData?=null, tag: String? = null)
     fun hide()
     var dialogListener: EmaDialogListener?
 


### PR DESCRIPTION
Why:
    - Cause the tag should be set. Sometimes an application could have different instances of the same type of dialog in one view.
How:
    - Moving the getTag function to a variable that could be set in the show function.