### PR TITLE
Updating Gradle and dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'kotlin-kapt'
 
 
 android {
-    buildToolsVersion ema.buildTools
     defaultConfig {
         applicationId "es.babel.ema"
         minSdkVersion ema.minSdk
@@ -36,11 +35,13 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
-
     packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/DEPENDENCIES'
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
     }
+
+    namespace 'es.babel.easymvvm'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="es.babel.easymvvm">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name="es.babel.easymvvm.presentation.EmaSampleApplication"
@@ -13,13 +12,16 @@
         android:theme="@style/AppTheme.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning">
 
-        <activity android:name="es.babel.easymvvm.presentation.ui.home.EmaHomeActivity">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN"/>
+        <activity
+            android:name="es.babel.easymvvm.presentation.ui.home.EmaHomeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-            <category android:name="android.intent.category.LAUNCHER"/>
-        </intent-filter>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
+
         <activity
             android:name=".presentation.ui.error.EmaErrorToolbarViewActivity"
             android:launchMode="singleInstance" />

--- a/build-system/dependencies.gradle
+++ b/build-system/dependencies.gradle
@@ -8,30 +8,28 @@ rootProject.ext {
 
     kodeinVersion = "6.5.5"
 
-    constraintVersion = "2.0.4"
+    constraintVersion = "2.1.3"
 
-    designVersion = "28.0.0"
+    materialVersion = "1.6.0"
 
-    materialVersion = "1.2.1"
+    coroutinesVersion = "1.6.1"
 
-    coroutinesVersion = "1.3.8"
+    testVersion = "1.4.0"
 
-    testVersion = "1.3.0"
+    extJUnitVersion = "1.1.3"
 
-    extJUnitVersion = "1.1.2"
+    mockitoVersion = "4.5.1"
 
-    mockitoVersion = "3.7.7"
+    archTesting = "2.1.0"
 
-    archTesting = "2.0.0"
-
-    espressoVersion = "3.3.0"
+    espressoVersion = "3.4.0"
 
 
     ema = [
             buildTools : "29.0.2",
             minSdk     : 21,
-            compileSdk : 28,
-            targetSdk  : 28,
+            compileSdk : 32,
+            targetSdk  : 32,
             versionCode: 24,
             versionName: "2.4.2"
     ]
@@ -68,14 +66,13 @@ rootProject.ext {
             rules      : "androidx.test:rules:" + project.testVersion,
             junitKotlin: "androidx.test.ext:junit-ktx:" + project.extJUnitVersion,
             mockito    : "org.mockito:mockito-core:" + project.mockitoVersion,
-            archTesting: "android.arch.core:core-testing:" + project.archTesting
+            archTesting: "androidx.arch.core:core-testing:" + project.archTesting
     ]
 
     emaAndroid = [
             navigationFragment: "androidx.navigation:navigation-fragment-ktx:" + project.navigationVersion,
             navigationUI      : "androidx.navigation:navigation-ui-ktx:" + project.navigationVersion,
             constraint        : "androidx.constraintlayout:constraintlayout:" + project.constraintVersion,
-            design            : "com.android.support:design:" + project.designVersion,
             material          : "com.google.android.material:material:" + project.materialVersion,
             lifecycle         : "androidx.lifecycle:lifecycle-extensions:" + project.lifecycleVersion,
             kodein            : "org.kodein.di:kodein-di-generic-jvm:" + project.kodeinVersion,

--- a/build.gradle
+++ b/build.gradle
@@ -10,15 +10,12 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        //maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$buildGradleVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$safeArgsVersion"
-        //classpath "com.github.dcendents:android-maven-gradle-plugin:$publishJitPackVersion"
-
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -33,7 +30,6 @@ allprojects {
         mavenCentral()
         google()
         maven { url "https://jitpack.io" }
-       // maven { url 'https://maven.google.com' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,22 @@
 apply from: 'build-system/dependencies.gradle'
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
-    ext.buildGradleVersion = '4.1.2'
+    ext.kotlin_version = '1.6.21'
+    ext.buildGradleVersion = '7.2.0'
     ext.safeArgsVersion = "1.0.0"
     ext.publishJitPackVersion = "2.1"
 
     repositories {
         mavenCentral()
         google()
-        maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
+        //maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$buildGradleVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$safeArgsVersion"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:$publishJitPackVersion"
+        //classpath "com.github.dcendents:android-maven-gradle-plugin:$publishJitPackVersion"
 
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -33,9 +32,8 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         maven { url "https://jitpack.io" }
-        maven { url 'https://maven.google.com' }
+       // maven { url 'https://maven.google.com' }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,13 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion ema.compileSdk
-    buildToolsVersion ema.buildTools
 
     defaultConfig {
         minSdkVersion ema.minSdk
         targetSdkVersion ema.targetSdk
-        versionCode ema.versionCode
-        versionName ema.versionName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -30,6 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'es.babel.common'
 
 }
 

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.babel.common"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -3,13 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion ema.compileSdk
-    buildToolsVersion ema.buildTools
 
     defaultConfig {
         minSdkVersion ema.minSdk
         targetSdkVersion ema.targetSdk
-        versionCode ema.versionCode
-        versionName ema.versionName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -30,6 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'es.babel.data'
 
 }
 

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.babel.data" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/easymvvm-android/build.gradle
+++ b/easymvvm-android/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 android {
@@ -9,8 +9,6 @@ android {
         minSdkVersion ema.minSdk
         compileSdkVersion ema.compileSdk
         targetSdkVersion ema.targetSdk
-        versionCode ema.versionCode
-        versionName ema.versionName
     }
 
     buildTypes {
@@ -26,6 +24,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'es.babel.easymvvm.android'
 
 }
 
@@ -43,7 +42,6 @@ dependencies {
 
     //UI
     api emaAndroid.constraint
-    api emaAndroid.design
     api emaAndroid.material
 
     api project(path: ':easymvvm-core')

--- a/easymvvm-android/build.gradle
+++ b/easymvvm-android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-//apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 android {

--- a/easymvvm-android/src/main/AndroidManifest.xml
+++ b/easymvvm-android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest
-    package="es.babel.easymvvm.android"/>
+<manifest />

--- a/easymvvm-core/build.gradle
+++ b/easymvvm-core/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'kotlin'
-apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 dependencies {

--- a/easymvvm-testing-android/build.gradle
+++ b/easymvvm-testing-android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-//apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 android {

--- a/easymvvm-testing-android/build.gradle
+++ b/easymvvm-testing-android/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 android {
@@ -9,8 +9,6 @@ android {
         minSdkVersion ema.minSdk
         compileSdkVersion ema.compileSdk
         targetSdkVersion ema.targetSdk
-        versionCode ema.versionCode
-        versionName ema.versionName
     }
 
     buildTypes {
@@ -30,6 +28,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'es.babel.easymvvm.testing.android'
 
 }
 

--- a/easymvvm-testing-android/src/main/AndroidManifest.xml
+++ b/easymvvm-testing-android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest
-    package="es.babel.easymvvm.testing.android"/>
+<manifest />

--- a/easymvvm-testing-core/build.gradle
+++ b/easymvvm-testing-core/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'kotlin'
-apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.babel-cdm'
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/injection/build.gradle
+++ b/injection/build.gradle
@@ -4,13 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 android {
 
     compileSdkVersion ema.compileSdk
-    buildToolsVersion ema.buildTools
 
     defaultConfig {
         minSdkVersion ema.minSdk
         targetSdkVersion ema.targetSdk
-        versionCode ema.versionCode
-        versionName ema.versionName
 
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -32,6 +29,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'es.babel.injection'
 
 }
 

--- a/injection/src/main/AndroidManifest.xml
+++ b/injection/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.babel.injection" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Updates are included for several of the libraries that are currently implemented within the project, except for some specific ones due to detection of bugs that will be modified later to make them compatible

Major update has been made within the Kotlin and Gradle versions:

> Kotlin 1.3.72 > 1.6.21
> Gradle 4.1.2 > 7.2.0

Build and Target version have been updated to API Level 32 code referencing Android 12:

> compileSdk 28 > 32
> compileSdk 28 > 32

Several migrations have been included after updating Gradle, jCenter() has been removed, which is deprecated, and on the other hand the Maven plugin has also been removed, since the management of the library updates are handled by Jitpack, so there is no need for this plugin, and it is also deprecated