### PR TITLE
Updating Gradle and dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,12 +32,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     packagingOptions {
         resources {

--- a/app/src/main/java/es/babel/easymvvm/presentation/dialog/simple/SimpleDialog.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/dialog/simple/SimpleDialog.kt
@@ -6,7 +6,6 @@ import es.babel.easymvvm.android.ui.dialog.EmaBaseBottomSheetDialog
 import es.babel.easymvvm.databinding.DialogSimpleBinding
 import es.babel.easymvvm.databinding.FragmentUserBinding
 import es.babel.easymvvm.databinding.ItemBackUserBinding
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 
 /**
  * Simple dialog

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/creation/EmaBackUserCreationFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/creation/EmaBackUserCreationFragment.kt
@@ -2,11 +2,11 @@ package es.babel.easymvvm.presentation.ui.backdata.creation
 
 import android.widget.Toast
 import es.babel.easymvvm.R
+import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.extension.checkNull
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentBackResultBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 import es.babel.easymvvm.presentation.ui.backdata.EmaBackNavigator
 import org.kodein.di.generic.instance
 

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/userlist/EmaBackUserFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/userlist/EmaBackUserFragment.kt
@@ -4,10 +4,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import es.babel.easymvvm.R
 import es.babel.easymvvm.android.extension.checkVisibility
+import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentBackBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 import es.babel.easymvvm.presentation.ui.backdata.EmaBackNavigator
 import org.kodein.di.generic.instance
 

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
@@ -2,10 +2,10 @@ package es.babel.easymvvm.presentation.ui.error
 
 import android.view.View
 import es.babel.easymvvm.R
+import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentErrorBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 import org.kodein.di.generic.instance
 
 class EmaErrorViewFragment : BaseFragment<EmaErrorState, EmaErrorViewModel, EmaErrorNavigator.Navigation>() {

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeFragment.kt
@@ -11,6 +11,7 @@ import es.babel.domain.exception.PasswordEmptyException
 import es.babel.domain.exception.UserEmptyException
 import es.babel.easymvvm.R
 import es.babel.easymvvm.android.extension.checkUpdate
+import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.constants.INT_ZERO
 import es.babel.easymvvm.core.constants.STRING_EMPTY
 import es.babel.easymvvm.core.dialog.EmaDialogProvider
@@ -22,7 +23,6 @@ import es.babel.easymvvm.presentation.dialog.loading.LoadingDialogData
 import es.babel.easymvvm.presentation.dialog.simple.SimpleDialogData
 import es.babel.easymvvm.presentation.dialog.simple.SimpleDialogListener
 import es.babel.easymvvm.presentation.dialog.simple.SimpleDialogProvider
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 import org.kodein.di.generic.instance
 
 /**

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/user/EmaUserFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/user/EmaUserFragment.kt
@@ -5,12 +5,12 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import es.babel.easymvvm.R
 import es.babel.easymvvm.android.extension.getFormattedString
+import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.android.navigation.EmaNavigator
 import es.babel.easymvvm.core.navigator.EmaNavigationState
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentUserBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
-import es.babel.easymvvm.presentation.extensions.viewbinding.viewBinding
 import es.babel.easymvvm.presentation.ui.home.EmaHomeToolbarViewModel
 import org.kodein.di.generic.instance
 

--- a/build-system/dependencies.gradle
+++ b/build-system/dependencies.gradle
@@ -6,13 +6,15 @@ rootProject.ext {
 
     lifecycleVersion = "2.2.0"
 
+    lifecycleVersionJava8 = "2.3.1"
+
     kodeinVersion = "6.5.5"
 
-    constraintVersion = "2.1.3"
+    constraintVersion = "2.1.4"
 
-    materialVersion = "1.6.0"
+    materialVersion = "1.6.1"
 
-    coroutinesVersion = "1.6.1"
+    coroutinesVersion = "1.6.3"
 
     testVersion = "1.4.0"
 
@@ -38,7 +40,7 @@ rootProject.ext {
     ]
 
     dataDependencies = [
-            kotlin    : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:" + project.kotlin_version,
+            kotlin    : "org.jetbrains.kotlin:kotlin-stdlib:" + project.kotlin_version,
             coroutines: 'org.jetbrains.kotlinx:kotlinx-coroutines-android:' + project.coroutinesVersion
     ]
 
@@ -54,7 +56,7 @@ rootProject.ext {
     ]
 
     emaCore = [
-            kotlin    : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:" + project.kotlin_version,
+            kotlin    : "org.jetbrains.kotlin:kotlin-stdlib:" + project.kotlin_version,
             coroutines: 'org.jetbrains.kotlinx:kotlinx-coroutines-android:' + project.coroutinesVersion
     ]
 
@@ -75,7 +77,7 @@ rootProject.ext {
             constraint        : "androidx.constraintlayout:constraintlayout:" + project.constraintVersion,
             material          : "com.google.android.material:material:" + project.materialVersion,
             lifecycle         : "androidx.lifecycle:lifecycle-extensions:" + project.lifecycleVersion,
-            lifecycleCommon   : "androidx.lifecycle:lifecycle-common-java8:" + project.lifecycleVersion,
+            lifecycleCommon   : "androidx.lifecycle:lifecycle-common-java8:" + project.lifecycleVersionJava8,
             kodein            : "org.kodein.di:kodein-di-generic-jvm:" + project.kodeinVersion,
             kodeinAndroid     : "org.kodein.di:kodein-di-framework-android-x:" + project.kodeinVersion,
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply from: 'build-system/dependencies.gradle'
 buildscript {
 
     ext.kotlin_version = '1.6.21'
-    ext.buildGradleVersion = '7.2.0'
+    ext.buildGradleVersion = '7.2.1'
     ext.safeArgsVersion = "1.0.0"
     ext.publishJitPackVersion = "2.1"
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,13 +24,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
+
+    packagingOptions {
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
+    }
+
     namespace 'es.babel.common'
 
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -24,13 +24,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
+
+    packagingOptions {
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
+    }
+
     namespace 'es.babel.data'
 
 }

--- a/easymvvm-android/build.gradle
+++ b/easymvvm-android/build.gradle
@@ -24,9 +24,16 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+
+    packagingOptions {
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
+    }
+
     namespace 'es.babel.easymvvm.android'
 
 }

--- a/easymvvm-android/build.gradle
+++ b/easymvvm-android/build.gradle
@@ -10,6 +10,10 @@ android {
         targetSdkVersion ema.targetSdk
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     buildTypes {
         debug {
         }

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/extension/ViewBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/extension/ViewBinding.kt
@@ -1,4 +1,4 @@
-package es.babel.easymvvm.presentation.extensions.viewbinding
+package es.babel.easymvvm.android.extension
 
 import android.view.LayoutInflater
 import android.view.View

--- a/easymvvm-testing-android/build.gradle
+++ b/easymvvm-testing-android/build.gradle
@@ -20,13 +20,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
+
+    packagingOptions {
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
+    }
+
     namespace 'es.babel.easymvvm.testing.android'
 
 }

--- a/easymvvm-testing-core/src/main/java/es/babel/easymvvm/testing/core/EmaTest.kt
+++ b/easymvvm-testing-core/src/main/java/es/babel/easymvvm/testing/core/EmaTest.kt
@@ -17,7 +17,7 @@ abstract class EmaTest {
 
     @Before
     open fun setup() {
-        MockitoAnnotations.initMocks(this)
+        MockitoAnnotations.openMocks(this)
         onSetup()
         runBlocking {
             onSetupSuspend()

--- a/injection/build.gradle
+++ b/injection/build.gradle
@@ -26,13 +26,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
+
+    packagingOptions {
+        resources {
+            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
+        }
+    }
+
     namespace 'es.babel.injection'
 
 }


### PR DESCRIPTION
Updates are included for several of the libraries that are currently implemented within the project, except for some specific ones due to detection of bugs that will be modified later to make them compatible

Update has been made within the Gradle version:

> Gradle 7.2.0 > 7.2.1

Update of compileOptions and kotlinOptions for Java, after the last updates of Android Studio they recommend the use of Java 11, so updates have been made adapting it to that version:

> sourceCompatibility JavaVersion.VERSION_1_8 > JavaVersion.VERSION_11
> targetCompatibility JavaVersion.VERSION_1_8 > JavaVersion.VERSION_11
> jvmTarget JavaVersion.VERSION_1_8 > JavaVersion.VERSION_11

The exclusion of 'META-INF/LICENSE' and 'META-INF/DEPENDENCIES' has been included in some remaining modules:

```
    packagingOptions {
        resources {
            excludes += ['META-INF/LICENSE', 'META-INF/DEPENDENCIES']
        }
    }
```

Updates for different dependencies that were implemented within the library are also included. In addition to updating a deprecated feature of Mockito after its implementation was updated