### PR TITLE
Update of implementation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Add the **EMA** dependencies
   >
 
     dependencies {
-          implementation 'com.github.babel-cdm.EMA:ema-android:2.4.2'
+          implementation 'com.github.babel-cdm.ema:easymvvm-core:2.4.2'
+          implementation 'com.github.babel-cdm.ema:easymvvm-android:2.4.2'
     }
 
 To use **test support library** add the following ones:
@@ -31,6 +32,6 @@ To use **test support library** add the following ones:
   >
 
     dependencies {
-          implementation  'com.github.babel-cdm.EMA:ema-testing-core:2.4.2'
-          implementation  'com.github.babel-cdm.EMA:ema-testing-android:2.4.2'
+          implementation  'com.github.babel-cdm.ema:easymvvm-testing-core:2.4.2'
+          implementation  'com.github.babel-cdm.ema:easymvvm-testing-android:2.4.2'
     }


### PR DESCRIPTION
Different modifications have been made within the README to include correcting the way of declaring the dependency within a project, thus showing the correct implementation of EMA

>  'com.github.babel-cdm.EMA:ema-core:2.4.2' >  'com.github.babel-cdm.ema:easymvvm-core:2.4.2'
>  'com.github.babel-cdm.EMA:ema-android:2.4.2' > 'com.github.babel-cdm.ema:easymvvm-android:2.4.2'
>  'com.github.babel-cdm.EMA:ema-testing-core:2.4.2' > 'com.github.babel-cdm.ema:easymvvm-testing-core:2.4.2'
>  'com.github.babel-cdm.EMA:ema-testing-android:2.4.2' > 'com.github.babel-cdm.ema:easymvvm-testing-android:2.4.2'