### PR TITLE
Including a small example of Jetpack Compose in EMA

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,13 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
-    buildFeatures.viewBinding = true
+    buildFeatures {
+        viewBinding = true
+        compose = true
+    }
+
+    composeOptions.kotlinCompilerExtensionVersion = "1.2.0-rc02"
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 
     flavorDimensions 'default'
 
@@ -56,4 +62,19 @@ dependencies {
     implementation project(path: ':injection')
 
     implementation project(path: ':easymvvm-android')
+
+    implementation emaCompose.composeUI
+    implementation emaCompose.materialCompose
+    implementation emaCompose.toolingComposePreview
+    implementation emaCompose.composeTooling
+    implementation emaCompose.activityCompose
+    implementation emaCompose.composeMaterialIcons
+    implementation emaCompose.foundationCompose
+    implementation emaCompose.foundationLayoutCompose
+    implementation emaCompose.animationCompose
+    implementation emaCompose.runtimeCompose
+    implementation emaCompose.constraintlayoutCompose
+    implementation emaCompose.material
+    implementation emaCompose.appCompat
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning">
-
+        <activity
+            android:name=".presentation.ui.compose.ComposeViewActivity"
+            android:exported="false" />
         <activity
             android:name="es.babel.easymvvm.presentation.ui.home.EmaHomeActivity"
             android:exported="true">
@@ -21,7 +23,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".presentation.ui.error.EmaErrorToolbarViewActivity"
             android:launchMode="singleInstance" />

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/ComposeViewActivity.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/ComposeViewActivity.kt
@@ -1,0 +1,130 @@
+package es.babel.easymvvm.presentation.ui.compose
+
+import android.os.Bundle
+import android.view.Gravity.CENTER
+import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.android.material.button.MaterialButton
+import es.babel.easymvvm.R
+import es.babel.easymvvm.presentation.ui.compose.theme.BabelTheme
+import es.babel.easymvvm.presentation.ui.compose.theme.darkOrange
+import es.babel.easymvvm.presentation.ui.compose.theme.lightOrange
+import es.babel.easymvvm.presentation.ui.compose.theme.tealOrange
+
+class ComposeViewActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            BabelTheme {
+                ComposeView()
+            }
+        }
+    }
+
+}
+
+@Composable
+fun ComposeView() {
+
+    // Scaffold: Generic template with various components commonly used on Android screens
+    Scaffold(
+
+        // TopBar: In it we will introduce the Composable we want to show as Toolbar
+        // at the top of the screen, if we do not customise any we can use
+        // the default one called TopAppBar
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Compose View")
+                },
+                backgroundColor = lightOrange,
+                elevation = 0.dp
+            )
+        },
+
+        // FloatingButton: This will be the floating button that we will show at the bottom
+        // right or left and where we can put different actions we want or
+        // navigate to other screens
+        floatingActionButtonPosition = FabPosition.End,
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {  },
+                backgroundColor = darkOrange,
+                elevation = FloatingActionButtonDefaults.elevation(
+                    defaultElevation = 0.dp,
+                    pressedElevation = 0.dp
+                )
+            ) { Text("X") }
+        },
+
+        // DrawerContent: In this we will introduce the Composable we want to show
+        // in the drop-down menu on the sides (in my opinion these types of menus are
+        // less and less used every day)
+        drawerContent = { Text(text = "DrawerContent") },
+        backgroundColor = tealOrange
+    ) { paddingValues ->
+
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            // Compose State
+            val state = remember { mutableStateOf(0) }
+
+            // Use Android Widget Image View to load images with XML format
+            AndroidView(factory = { ctx ->
+                ImageView(ctx).apply {
+                    val drawable = ContextCompat.getDrawable(ctx, R.drawable.ic_error)
+                    setImageDrawable(drawable)
+                }
+            })
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            // Use Material Button to load a Button with Material style with XML format
+            AndroidView(factory = { ctx ->
+                MaterialButton(ctx).apply {
+                    text = "Android XML Buttom"
+                    layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+                    setOnClickListener { state.value++ }
+                }
+            })
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            // Use Android Widget Text to load a string with XML format
+            AndroidView(factory = { ctx ->
+                TextView(ctx).apply {
+                    layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+                    textAlignment = View.TEXT_ALIGNMENT_CENTER
+                }
+            }, update = {
+                it.text = "You have clicked the buttons: ${state.value} times"
+            })
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Colors.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Colors.kt
@@ -1,0 +1,7 @@
+package es.babel.easymvvm.presentation.ui.compose.theme
+
+import androidx.compose.ui.graphics.Color
+
+val lightOrange = Color(0xFFFFB517)
+val darkOrange = Color(0xFFC68700)
+val tealOrange = Color(0xFFD8B260)

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Shape.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Shape.kt
@@ -1,0 +1,11 @@
+package es.babel.easymvvm.presentation.ui.compose.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Shapes
+import androidx.compose.ui.unit.dp
+
+val Shapes = Shapes(
+    small = RoundedCornerShape(4.dp),
+    medium = RoundedCornerShape(4.dp),
+    large = RoundedCornerShape(0.dp)
+)

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Theme.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Theme.kt
@@ -1,0 +1,48 @@
+package es.babel.easymvvm.presentation.ui.compose.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+
+/**
+    Other default colors to override
+       - background = Color.White,
+       - surface = Color.White,
+       - onPrimary = Color.White,
+       - onSecondary = Color.Black,
+       - onBackground = Color.Black,
+       - onSurface = Color.Black
+ **/
+
+private val DarkColorPalette = darkColors(
+    primary = lightOrange,
+    primaryVariant = darkOrange,
+    secondary = tealOrange
+)
+
+private val LightColorPalette = lightColors(
+    primary = lightOrange,
+    primaryVariant = darkOrange,
+    secondary = tealOrange
+)
+
+@Composable
+fun BabelTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+
+    MaterialTheme(
+        colors = colors,
+        typography = Typography,
+        shapes = Shapes,
+        content = content
+    )
+}

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Type.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/compose/theme/Type.kt
@@ -1,0 +1,29 @@
+package es.babel.easymvvm.presentation.ui.compose.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    body1 = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
+    )
+    /**
+        Other default text styles to override
+            button = TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.W500,
+                fontSize = 14.sp
+            ),
+            caption = TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 12.sp
+            )
+    */
+)

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorToolbarViewActivity.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorToolbarViewActivity.kt
@@ -3,14 +3,14 @@ package es.babel.easymvvm.presentation.ui.error
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import es.babel.easymvvm.R
-import es.babel.easymvvm.android.ui.EmaActivity
-import es.babel.easymvvm.core.state.EmaExtraData
-import es.babel.easymvvm.presentation.injection.activityInjection
 import es.babel.easymvvm.android.extension.dpToPx
 import es.babel.easymvvm.android.extension.getColorCompat
 import es.babel.easymvvm.android.extension.getFormattedString
-import es.babel.easymvvm.presentation.ui.backdata.EmaBackToolbarState
+import es.babel.easymvvm.android.ui.EmaActivity
+import es.babel.easymvvm.core.state.EmaExtraData
+import es.babel.easymvvm.presentation.injection.activityInjection
 import org.kodein.di.Kodein
 import org.kodein.di.generic.instance
 import kotlin.math.roundToInt
@@ -28,7 +28,7 @@ class EmaErrorToolbarViewActivity : EmaActivity<EmaErrorToolbarState, EmaErrorTo
 
     override val navGraph: Int = R.navigation.navigation_ema_error
 
-    override fun provideFixedToolbarTitle(): String? = getString(R.string.error_toolbar_title)
+    override fun provideFixedToolbarTitle(): String = getString(R.string.error_toolbar_title)
 
     override val viewModelSeed: EmaErrorToolbarViewModel by instance()
 
@@ -49,7 +49,7 @@ class EmaErrorToolbarViewActivity : EmaActivity<EmaErrorToolbarState, EmaErrorTo
         toolbar.apply {
             val whiteColor = android.R.color.white.getColorCompat(applicationContext)
             setBackgroundColor(R.color.colorPrimary.getColorCompat(applicationContext))
-            logo = getDrawable(R.drawable.ic_error_toolbar)
+            logo =  AppCompatResources.getDrawable(context, R.drawable.ic_error_toolbar)
             setTitleTextColor(whiteColor)
             titleMarginStart = resources.getDimension(R.dimen.space_medium).roundToInt().dpToPx(context)
 
@@ -80,7 +80,7 @@ class EmaErrorToolbarViewActivity : EmaActivity<EmaErrorToolbarState, EmaErrorTo
 
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_error, menu)
         return true
     }

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
@@ -9,6 +9,7 @@ import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentErrorBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
+import es.babel.easymvvm.presentation.ui.compose.ComposeViewActivity
 import org.kodein.di.generic.instance
 
 

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/error/EmaErrorViewFragment.kt
@@ -1,12 +1,16 @@
 package es.babel.easymvvm.presentation.ui.error
 
+import android.content.Intent
 import android.view.View
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import es.babel.easymvvm.R
 import es.babel.easymvvm.android.extension.viewBinding
 import es.babel.easymvvm.core.state.EmaExtraData
 import es.babel.easymvvm.databinding.FragmentErrorBinding
 import es.babel.easymvvm.presentation.base.BaseFragment
 import org.kodein.di.generic.instance
+
 
 class EmaErrorViewFragment : BaseFragment<EmaErrorState, EmaErrorViewModel, EmaErrorNavigator.Navigation>() {
 
@@ -33,6 +37,13 @@ class EmaErrorViewFragment : BaseFragment<EmaErrorState, EmaErrorViewModel, EmaE
     private fun setupButtons(viewModel: EmaErrorViewModel) = with(binding) {
         bErrorToolbar.setOnClickListener { viewModel.onActionToolbar() }
         bErrorAddUser.setOnClickListener { viewModel.onActionAddUser() }
+        btnComposableView.setContent {
+            Button(
+                onClick = {
+                    startActivity(Intent(requireContext(), ComposeViewActivity::class.java))
+                }
+            ) { Text(text = "Open Composable View") }
+        }
     }
 
     override fun onNormal(data: EmaErrorState) {

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeActivity.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeActivity.kt
@@ -1,6 +1,7 @@
 package es.babel.easymvvm.presentation.ui.home
 
 import android.widget.Toast
+import androidx.navigation.NavController
 import es.babel.easymvvm.R
 import es.babel.easymvvm.android.extension.DATE_FORMAT_HHMM
 import es.babel.easymvvm.android.extension.getFormattedString
@@ -30,7 +31,7 @@ class EmaHomeActivity : BaseActivity<EmaHomeToolbarState, EmaHomeToolbarViewMode
 
     }
 
-    override fun provideFixedToolbarTitle(): String? = getString(R.string.home_toolbar_title)
+    override fun provideFixedToolbarTitle(): String = getString(R.string.home_toolbar_title)
 
     /**
      * Variable used to enable the theme used in manifest. Otherwise it will use the EmaTheme,

--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeFragment.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/home/EmaHomeFragment.kt
@@ -6,6 +6,19 @@ import android.text.method.PasswordTransformationMethod
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+/*import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp*/
 import es.babel.domain.exception.LoginException
 import es.babel.domain.exception.PasswordEmptyException
 import es.babel.domain.exception.UserEmptyException
@@ -56,6 +69,7 @@ class EmaHomeFragment : BaseFragment<EmaHomeState, EmaHomeViewModel, EmaHomeNavi
     override fun onInitialized(viewModel: EmaHomeViewModel) {
         setupButtons(viewModel)
         setupDialog(viewModel)
+        setUpComposeViews()
     }
 
     private fun setupDialog(viewModel: EmaHomeViewModel) {
@@ -146,6 +160,19 @@ class EmaHomeFragment : BaseFragment<EmaHomeState, EmaHomeViewModel, EmaHomeNavi
                 ))
     }
 
+    private fun setUpComposeViews() = with(binding) {
+
+        //We tell ComposeView what its content is, we can include it directly,
+        // or we can create a Composable function in which we introduce our design
+        tvLoginWelcomeTextCompose?.setContent {
+            Text(
+                modifier = Modifier.padding(top = 15.dp),
+                text = stringResource(id = R.string.home_identify),
+                fontSize = 14.sp
+            )
+        }
+
+    }
 
     override fun onNormal(data: EmaHomeState) = with(binding) {
 

--- a/app/src/main/res/layout-land/fragment_home.xml
+++ b/app/src/main/res/layout-land/fragment_home.xml
@@ -110,7 +110,7 @@
         app:layout_constraintEnd_toEndOf="@+id/bLightLoginSign"
         app:layout_constraintStart_toStartOf="@+id/bLightLoginSign"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/bLightLoginSign"
         style="@style/ButtonRed"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/dialog_simple.xml
+++ b/app/src/main/res/layout/dialog_simple.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/bDialogSimpleYes"
             style="@style/ButtonRed"
             android:layout_width="wrap_content"
@@ -29,6 +29,7 @@
             android:text="@string/dialog_yes"
             android:textSize="@dimen/letter_big"
             android:textStyle="normal"
+            app:backgroundTint="@android:color/holo_orange_dark"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
@@ -37,7 +38,7 @@
             app:layout_constraintVertical_bias="0.0" />
 
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/bDialogSimpleNo"
             style="@style/ButtonWhite"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_back.xml
+++ b/app/src/main/res/layout/fragment_back.xml
@@ -7,7 +7,7 @@
     android:background="@color/white"
     android:orientation="vertical">
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/bBack"
         style="@style/ButtonGreen"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_back_result.xml
+++ b/app/src/main/res/layout/fragment_back_result.xml
@@ -75,7 +75,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/bBackResultAccept"
         style="@style/ButtonGreen"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_error.xml
+++ b/app/src/main/res/layout/fragment_error.xml
@@ -42,19 +42,20 @@
         app:layout_constraintTop_toBottomOf="@+id/imageView"
         app:layout_constraintVertical_chainStyle="spread" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/bErrorToolbar"
         style="@style/ButtonWhite"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/error_show_toolbar"
+        android:textColor="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvErrorDescription" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/bErrorAddUser"
         style="@style/ButtonGreen"
         android:layout_width="wrap_content"
@@ -68,5 +69,13 @@
         app:layout_constraintTop_toBottomOf="@+id/bErrorToolbar"
         app:layout_constraintVertical_bias="0.0" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/btnComposableView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/bErrorAddUser" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -23,14 +23,10 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0"/>
 
-    <TextView
-        android:id="@+id/tvLoginWelcomeText"
-        style="@style/TextMedium"
-        android:textSize="@dimen/letter_medium"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/tvLoginWelcomeTextCompose"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_big_medium"
-        android:text="@string/home_identify"
         app:layout_constraintEnd_toEndOf="@+id/tvLoginWelcome"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@+id/tvLoginWelcome"
@@ -42,10 +38,10 @@
         layout="@layout/layout_user"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/tvLoginWelcomeText"
-        app:layout_constraintEnd_toEndOf="@+id/tvLoginWelcomeText"
+        app:layout_constraintTop_toBottomOf="@+id/tvLoginWelcomeTextCompose"
+        app:layout_constraintEnd_toEndOf="@+id/tvLoginWelcomeTextCompose"
         app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="@+id/tvLoginWelcomeText"/>
+        app:layout_constraintStart_toStartOf="@+id/tvLoginWelcomeTextCompose"/>
 
     <TextView
         android:id="@+id/tvLightLoginErrorUser"
@@ -111,7 +107,7 @@
             android:textSize="@dimen/letter_small_medium"
             android:textStyle="bold" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/bLightLoginSign"
             style="@style/ButtonRed"
             android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,1 @@
+<resources></resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/build-system/dependencies.gradle
+++ b/build-system/dependencies.gradle
@@ -26,6 +26,13 @@ rootProject.ext {
 
     espressoVersion = "3.4.0"
 
+    jetpackCompose = "1.2.0-rc02"
+
+    constraintCompose = "1.0.1"
+
+    appCompat = "1.4.2"
+
+    activityCompose = "1.4.0"
 
     ema = [
             buildTools : "29.0.2",
@@ -80,6 +87,22 @@ rootProject.ext {
             lifecycleCommon   : "androidx.lifecycle:lifecycle-common-java8:" + project.lifecycleVersionJava8,
             kodein            : "org.kodein.di:kodein-di-generic-jvm:" + project.kodeinVersion,
             kodeinAndroid     : "org.kodein.di:kodein-di-framework-android-x:" + project.kodeinVersion,
+    ]
+
+    emaCompose = [
+            composeUI                   : "androidx.compose.ui:ui:" + project.jetpackCompose,
+            materialCompose             : "androidx.compose.material:material:" + project.jetpackCompose,
+            toolingComposePreview       : "androidx.compose.ui:ui-tooling-preview:" + project.jetpackCompose,
+            composeTooling              : "androidx.compose.ui:ui-tooling:" + project.jetpackCompose,
+            activityCompose             : "androidx.activity:activity-compose:" + project.activityCompose,
+            composeMaterialIcons        : "androidx.compose.material:material-icons-extended:" + project.jetpackCompose,
+            foundationCompose           : "androidx.compose.foundation:foundation:" + project.jetpackCompose,
+            foundationLayoutCompose     : "androidx.compose.foundation:foundation-layout:" + project.jetpackCompose,
+            animationCompose            : "androidx.compose.animation:animation:" + project.jetpackCompose,
+            runtimeCompose              : "androidx.compose.runtime:runtime:" + project.jetpackCompose,
+            constraintlayoutCompose     : "androidx.constraintlayout:constraintlayout-compose:" + project.constraintCompose,
+            material                    : "com.google.android.material:material:" + project.materialVersion,
+            appCompat                   : "androidx.appcompat:appcompat:" + project.appCompat
     ]
 
 }

--- a/easymvvm-android/src/main/res/values/styles.xml
+++ b/easymvvm-android/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="EmaAppTheme" parent="ThemeOverlay.AppCompat">
+    <style name="EmaAppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/emaBlue</item>
         <item name="colorPrimaryDark">@color/emaBlueDark</item>

--- a/easymvvm-core/src/main/java/es/babel/easymvvm/core/extension/EmaStringExtensions.kt
+++ b/easymvvm-core/src/main/java/es/babel/easymvvm/core/extension/EmaStringExtensions.kt
@@ -12,10 +12,6 @@ import es.babel.easymvvm.core.constants.STRING_EMPTY
  * @author <a href=“mailto:apps.carmabs@gmail.com”>Carlos Mateo Benito</a>
  */
 
-fun String?.checkNull(defaultValue: String = STRING_EMPTY): String {
-    return this ?: defaultValue
-}
+fun String?.checkNull(defaultValue: String = STRING_EMPTY): String = this ?: defaultValue
 
-fun String.getFormattedString(vararg data: Any?): String {
-    return String.format(this, *data)
-}
+fun String.getFormattedString(vararg data: Any?): String = String.format(this, *data)


### PR DESCRIPTION
A small example of compatibility has been included in EMA and in projects that still have XML for the development of new features in Jetpack Compose, for the use of Compose elements in layouts with XML, and even for the use of Compose but that XML elements can be included

In the case of wanting to introduce Compose elements in XML layouts we would simply have to introduce in our XML view the following code fragment:

```
    <androidx.compose.ui.platform.ComposeView
        android:id="@+id/btnComposableView"
        android:layout_width="wrap_content"
        android:layout_height="wrap_content" />
```

And inside our activity or fragment, in which we use ViewBinding, we would configure our Jetpack Compose element as follows:

```
        btnComposableView.setContent {
            Button(
                onClick = {
                    startActivity(Intent(requireContext(), ComposeViewActivity::class.java))
                }
            ) { Text(text = "Open Composable View") }
        }
```

In case we want to include an XML element inside a Composable, it can be done in a very simple way as shown in this code fragment:

```
            AndroidView(factory = { ctx ->
                MaterialButton(ctx).apply {
                    text = "Android XML Buttom"
                    layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
                    setOnClickListener { state.value++ }
                }
            })
```

Small corrections have been made, in addition to migrating the buttons to MaterialButton, including a complete compose module with themes, colors and shapes