### PR TITLE
Include EmaBaseActivityBinding

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaActivity.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaActivity.kt
@@ -60,7 +60,7 @@ abstract class EmaActivity<S : EmaBaseState, VM : EmaViewModel<S, NS>, NS : EmaN
      * Activity result function to execute the viewmodel function when activity result is received.
      */
     private val resultActivityFunctions: HashMap<Int, ((Int, Int, Intent?) -> Unit)> by lazy {
-        hashMapOf<Int, ((Int, Int, Intent?) -> Unit)>()
+        hashMapOf()
     }
 
     /**
@@ -125,7 +125,7 @@ abstract class EmaActivity<S : EmaBaseState, VM : EmaViewModel<S, NS>, NS : EmaN
      * The map which handles the view model attached with their respective scopes, to unbind the observers
      * when the view activity is destroyed
      */
-    private val extraViewModelMap: MutableList<EmaViewModel<*, *>> by lazy { mutableListOf<EmaViewModel<*, *>>() }
+    private val extraViewModelMap: MutableList<EmaViewModel<*, *>> by lazy { mutableListOf() }
 
     /**
      * Previous state for comparing state properties update
@@ -136,7 +136,6 @@ abstract class EmaActivity<S : EmaBaseState, VM : EmaViewModel<S, NS>, NS : EmaN
      * @param viewModelAttachedSeed is the view model seed will used as factory instance if there is no previous
      * view model retained by the OS
      * @param fragment the fragment scope
-     * @param fragmentActivity the activity scope, if it is provided this will be the scope of the view model attached
      * @param observerFunction the observer of the view model attached
      * @return The view model attached
      */

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
@@ -1,0 +1,47 @@
+package es.babel.easymvvm.android.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.NavHost
+import org.kodein.di.Kodein
+import org.kodein.di.KodeinAware
+import org.kodein.di.android.closestKodein
+
+/**
+ *
+ * Abstract base class to implement Kodein framework in activity context
+ * to handle dependency injection
+ *
+ */
+abstract class EmaBaseActivityBinding : AppCompatActivity(), NavHost, KodeinAware {
+
+    private val parentKodein by closestKodein()
+    override val kodein: Kodein = Kodein.lazy {
+        extend(parentKodein)
+        injectActivityModule(this)?.let {
+            import(it)
+        }
+    }
+
+    /**
+     * The onCreate base will inject dependencies and views.
+     *
+     */
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        onCreateActivity(savedInstanceState)
+    }
+
+    /**
+     * Method called once the content view of activity has been set
+     * @param savedInstanceState Instance state for activity recreation
+     */
+    abstract fun onCreateActivity(savedInstanceState: Bundle?)
+
+    /**
+     * The child classes implement this methods to return the module that provides the activity scope objects
+     * @param kodein The kodein object which provide the injection
+     * @return The Kodein module which makes the injection
+     */
+    abstract fun injectActivityModule(kodein: Kodein.MainBuilder): Kodein.Module?
+}


### PR DESCRIPTION
Due to the fact that the Base Activity currently available in EMA includes `setContentView`, a new Base has been created, called **EmaBaseActivityBinding**, which does not include within the `onCreate` the `setContentView` function passing it the `layoutId`, but it will be from the activity itself that is created within the project where the `setContentView` will be passed including the binding.root of the desired view.

This has been determined due to an error that has been found at the time of the implementation in which it is indicated that there is a duplicity at the time of setting the view