### PR TITLE
Include EmaFragmentActivityBinding

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
@@ -1,0 +1,63 @@
+package es.babel.easymvvm.android.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.navigation.NavController
+import androidx.navigation.findNavController
+import es.babel.easymvvm.android.R
+
+/**
+ * Abstract class to handle navigation in activity
+ *
+ *
+ */
+abstract class EmaFragmentActivityBinding : EmaBaseActivityBinding() {
+
+    override fun onCreateActivity(savedInstanceState: Bundle?) {
+        setupNavigation()
+    }
+
+    /**
+     * Get the nav controller to handle the navigation through navigation architecture components.
+     * The nav controller must be provided by an id called "navHostFragment"
+     */
+    override fun getNavController(): NavController {
+
+        try {
+            return findNavController(R.id.navHostFragment)
+        } catch (e: java.lang.RuntimeException) {
+            throw RuntimeException("You must provide in your activity xml a fragment with " +
+                    "android:id=@+ìd/navHostFragment as container " +
+                    "with android:name=androidx.navigation.fragment.NavHostFragment")
+        }
+
+    }
+
+    /**
+     * Setup the navigation path for navigation architecture components
+     */
+    private fun setupNavigation() {
+        navController.setGraph(navGraph, intent.extras)
+    }
+
+
+    /**
+     * Get the navigation resource for the activity [R.navigation]
+     */
+    abstract val navGraph: Int
+
+
+    /**
+     * Set up the up action navigation
+     */
+    override fun onSupportNavigateUp() =
+            findNavController(R.id.navHostFragment).navigateUp()
+
+    /**
+     * Get the view which acts as fragment container
+     */
+    protected fun getContentLayout(): View {
+        return findViewById(R.id.navHostFragment)
+    }
+
+}


### PR DESCRIPTION
Due to the fact that the Base Fragment Activity currently available in EMA includes `setContentView`, a new Base has been created, called ** EmaFragmentActivityBinding**, which does not include within the `onCreate` the `setContentView` function passing it the `layoutId`, but it will be from the activity itself that is created within the project where the `setContentView` will be passed including the binding.root of the desired view.

This has been determined due to an error that has been found at the time of the implementation in which it is indicated that there is a duplicity at the time of setting the view