### PR TITLE
[Second Revision] EmaBaseActivityBinding and EmaFragmentActivityBinding

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
@@ -16,8 +16,6 @@ import org.kodein.di.android.closestKodein
  */
 abstract class EmaBaseActivityBinding<B : ViewBinding> : AppCompatActivity(), NavHost, KodeinAware {
 
-    lateinit var binding: B
-
     private val parentKodein by closestKodein()
     override val kodein: Kodein = Kodein.lazy {
         extend(parentKodein)
@@ -33,15 +31,19 @@ abstract class EmaBaseActivityBinding<B : ViewBinding> : AppCompatActivity(), Na
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = getViewBinding()
-        setContentView(binding.root)
+        setContentView(bindingId.root)
         onCreateActivity(savedInstanceState)
     }
 
     /**
      * @return The binding that's gonna be the activity view.
      */
-    protected abstract fun getViewBinding(): B
+    protected abstract val bindingId: B
+
+    /**
+     * @return The layout ID that's gonna be the activity view [Deprecated]
+     */
+    protected abstract val layoutId: Int
 
     /**
      * Method called once the content view of activity has been set

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
@@ -62,6 +62,8 @@ abstract class EmaFragmentActivityBinding : EmaBaseActivityBinding<ViewBinding>(
         return findViewById(R.id.navHostFragment)
     }
 
-    override fun getViewBinding(): ViewBinding = EmaActivityFragmentBinding.inflate(layoutInflater)
+    override val layoutId: Int = R.layout.ema_activity_fragment
+
+    override val bindingId: ViewBinding = EmaActivityFragmentBinding.inflate(layoutInflater)
 
 }


### PR DESCRIPTION
Due to the fact that the Base Fragment Activity currently available in EMA includes `setContentView`, a new Base has been created, called **EmaFragmentActivityBinding**, which does not include within the `onCreate` the `setContentView` function passing it the `layoutId`, but it will be from the activity itself that is created within the project where the `setContentView` will be passed including the binding.root of the desired view.

This has been determined due to an error that has been found at the time of the implementation in which it is indicated that there is a duplicity at the time of setting the view