### PR TITLE
[Third Revision] EmaBaseActivityBinding and EmaFragmentActivityBinding

### DIFF
--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaBaseActivityBinding.kt
@@ -25,20 +25,20 @@ abstract class EmaBaseActivityBinding<B : ViewBinding> : AppCompatActivity(), Na
     }
 
     /**
-     * The onCreate base will set the view specified in [binding] and will
+     * The onCreate base will set the view specified in [bindingId] and will
      * inject dependencies and views.
      *
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(bindingId.root)
+        if (bindingId != null) setContentView(bindingId?.root)
         onCreateActivity(savedInstanceState)
     }
 
     /**
      * @return The binding that's gonna be the activity view.
      */
-    protected abstract val bindingId: B
+    protected abstract val bindingId: B?
 
     /**
      * @return The layout ID that's gonna be the activity view [Deprecated]

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.viewbinding.ViewBinding
 import es.babel.easymvvm.android.R
-import es.babel.easymvvm.android.databinding.EmaActivityFragmentBinding
 
 /**
  * Abstract class to handle navigation in activity
@@ -63,7 +62,5 @@ abstract class EmaFragmentActivityBinding : EmaBaseActivityBinding<ViewBinding>(
     }
 
     override val layoutId: Int = R.layout.ema_activity_fragment
-
-    override val bindingId: ViewBinding = EmaActivityFragmentBinding.inflate(layoutInflater)
 
 }


### PR DESCRIPTION
Due to the fact that the Base Fragment Activity currently available in EMA includes `setContentView`, a new Base has been created, called **EmaFragmentActivityBinding**, which does not include within the `onCreate` the `setContentView` function passing it the `layoutId`, but it will be from the activity itself that is created within the project where the `setContentView` will be passed including the binding.root of the desired view.

This has been determined due to an error that has been found at the time of the implementation in which it is indicated that there is a duplicity at the time of setting the view