### PR TITLE
Navigation library update

### DIFF
--- a/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/EmaBackToolbarActivity.kt
+++ b/app/src/main/java/es/babel/easymvvm/presentation/ui/backdata/EmaBackToolbarActivity.kt
@@ -1,4 +1,4 @@
-package es.babel.easymvvm.presentation.ui.backdata;
+package es.babel.easymvvm.presentation.ui.backdata
 
 import androidx.core.content.ContextCompat
 import es.babel.easymvvm.R

--- a/build-system/dependencies.gradle
+++ b/build-system/dependencies.gradle
@@ -2,7 +2,7 @@ rootProject.ext {
 
     //Libraries
 
-    navigationVersion = "2.3.3"
+    navigationVersion = "2.4.2"
 
     lifecycleVersion = "2.2.0"
 

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivity.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivity.kt
@@ -22,17 +22,8 @@ abstract class EmaFragmentActivity : EmaBaseActivity() {
      * Get the nav controller to handle the navigation through navigation architecture components.
      * The nav controller must be provided by an id called "navHostFragment"
      */
-    override fun getNavController(): NavController {
-
-        try {
-            return findNavController(R.id.navHostFragment)
-        } catch (e: java.lang.RuntimeException) {
-            throw RuntimeException("You must provide in your activity xml a fragment with " +
-                    "android:id=@+ìd/navHostFragment as container " +
-                    "with android:name=androidx.navigation.fragment.NavHostFragment")
-        }
-
-    }
+    override val navController: NavController
+        get() = findNavController(R.id.navHostFragment)
 
     /**
      * Setup the navigation path for navigation architecture components

--- a/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
+++ b/easymvvm-android/src/main/java/es/babel/easymvvm/android/ui/EmaFragmentActivityBinding.kt
@@ -22,17 +22,8 @@ abstract class EmaFragmentActivityBinding : EmaBaseActivityBinding<ViewBinding>(
      * Get the nav controller to handle the navigation through navigation architecture components.
      * The nav controller must be provided by an id called "navHostFragment"
      */
-    override fun getNavController(): NavController {
-
-        try {
-            return findNavController(R.id.navHostFragment)
-        } catch (e: java.lang.RuntimeException) {
-            throw RuntimeException("You must provide in your activity xml a fragment with " +
-                    "android:id=@+ìd/navHostFragment as container " +
-                    "with android:name=androidx.navigation.fragment.NavHostFragment")
-        }
-
-    }
+    override val navController: NavController
+        get() = findNavController(R.id.navHostFragment)
 
     /**
      * Setup the navigation path for navigation architecture components


### PR DESCRIPTION
The version of the navigation library has been updated from **2.3.3 to 2.4.2**, and the necessary adaptations have been made for its correct operation within the base screens, the function `getNavControlller` has been eliminated and replaced by the variable `navController` (both override)